### PR TITLE
Adds security

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ extensions like:
 * Spring Data JPA
 * Lombok
 * Validation
+* Security (authentication is basic in application.properties)
 * Mapstruct (added externally)
 
 I've created simple tree structure of the project, according 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/pl/test/learn/productdemo/configurations/SecurityConfig.java
+++ b/src/main/java/pl/test/learn/productdemo/configurations/SecurityConfig.java
@@ -1,0 +1,24 @@
+package pl.test.learn.productdemo.configurations;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 #spring.h2.console.enabled=true
 
-
+spring.security.user.name=user
+spring.security.user.password=password

--- a/src/test/java/pl/test/learn/productdemo/controllers/ProductControllerTest.java
+++ b/src/test/java/pl/test/learn/productdemo/controllers/ProductControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import pl.test.learn.productdemo.exceptions.NoSuchProductException;
 import pl.test.learn.productdemo.models.Product;
@@ -20,10 +21,12 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ProductController.class)
+@WithMockUser
 class ProductControllerTest {
 
     private static final String URL = "/products";
@@ -113,6 +116,7 @@ class ProductControllerTest {
 
         // when // then
         mockMvc.perform(post(URL)
+                        .with(csrf().asHeader())
                         .content(body)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -122,6 +126,7 @@ class ProductControllerTest {
     public void shouldUpdateProduct() throws Exception, NoSuchProductException {
         //given // when // then
         mockMvc.perform(put(URL_ID, QUERY_ID)
+                        .with(csrf().asHeader())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productDTO1)))
                 .andExpect(status().isOk());
@@ -137,6 +142,7 @@ class ProductControllerTest {
 
         // when // then
         mockMvc.perform(put(URL_ID, QUERY_ID)
+                        .with(csrf().asHeader())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidProduct)))
                 .andExpect(status().isBadRequest());
@@ -145,7 +151,8 @@ class ProductControllerTest {
     @Test
     public void shouldDeleteProduct() throws Exception, NoSuchProductException {
         //given // when // then
-        mockMvc.perform(delete(URL_ID, QUERY_ID))
+        mockMvc.perform(delete(URL_ID, QUERY_ID)
+                        .with(csrf().asHeader()))
                 .andExpect(status().isOk());
 
         verify(productService, times(1)).deleteProductById(anyLong());
@@ -157,7 +164,7 @@ class ProductControllerTest {
         //given // when // then
         doThrow(NoSuchProductException.class).when(productService).deleteProductById(anyLong());
 
-        mockMvc.perform(delete(URL_ID, QUERY_ID))
+        mockMvc.perform(delete(URL_ID, QUERY_ID).with(csrf().asHeader()))
                 .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
There is an issue with this. I don't know if it's a latest version of ecurity issue ? Endpoints work with basic http, but they hide data of entities with nulls( in postman for example) . All other actions work so when you create -> read -> delete for example its working fine. 